### PR TITLE
feat: add soundcloud drawer

### DIFF
--- a/web/src/lib/asmr/data.ts
+++ b/web/src/lib/asmr/data.ts
@@ -7,16 +7,18 @@ export const audio: { [key: string]: string } = {
   rain: '/asmr/sounds/rain.mp3',
   keyboard: '/asmr/sounds/typing-keyboard.mp3',
   phone: '/asmr/sounds/typing-iphone.mp3',
+  piano: '/asmr/sounds/piano-1.mp3',
 };
 
 export const audioPlaying: { [key: string]: boolean } = {};
 export const audioVolume: { [key: string]: number } = {
-  bird: 1,
-  fireplace: 0.8,
-  footsteps: 0.6,
-  rain: 0.8,
-  keyboard: 0.6,
-  phone: 0.6,
+  bird: 1.3,
+  fireplace: 1.1,
+  footsteps: 0.9,
+  rain: 1.1,
+  keyboard: 0.9,
+  phone: 0.9,
+  piano: 0.9,
 };
 
 export const modelPath: { [key: string]: string } = {
@@ -29,6 +31,7 @@ export const modelPath: { [key: string]: string } = {
   phone: '/asmr/models/iphone_x.glb',
   pikminPurple: '/asmr/models/pikmin-purple.glb',
   pikminRed: '/asmr/models/pikmin-red.glb',
+  piano: '/asmr/models/mini_piano.glb',
 };
 
 export const modelLoaded: { [key: string]: boolean } = {
@@ -41,6 +44,7 @@ export const modelLoaded: { [key: string]: boolean } = {
   phone: false,
   pikminPurple: false,
   pikminRed: false,
+  piano: false,
 };
 
 export const gltfCache: { [key: string]: GLTF } = {};

--- a/web/src/routes/asmr/+page.svelte
+++ b/web/src/routes/asmr/+page.svelte
@@ -16,6 +16,7 @@
     gltfCache,
   } from '$lib/asmr/data';
 	import Button from '$lib/components/ui/button/button.svelte';
+	import BottomDrawer from './soundButton.svelte';
 
   let scene: THREE.Scene;
   let container: HTMLDivElement;
@@ -29,6 +30,11 @@
   let draggableObjects: THREE.Object3D[] = [];
   let gui: dat.GUI
   let modelLoading = false;
+  let soundCloudActive = false;
+
+  function activateSoundCloud() {
+    soundCloudActive = !soundCloudActive;
+  }
 
   function onMouseMove(
     event: MouseEvent,
@@ -75,7 +81,7 @@
     }
     folder.add({ volume: volume || sound.getVolume() }, 'volume')
       .min(0)
-      .max(2)
+      .max(4)
       .step(0.1)
       .name('volume')
       .onChange((value: number) => sound.setVolume(value));
@@ -235,9 +241,19 @@
     camera.add(listener);
     renderer = new THREE.WebGLRenderer({antialias: true});
     gltfLoader = new GLTFLoader();
-    gui = new dat.GUI();
+    gui = new dat.GUI(
+      {
+        autoPlace: true,
+        width: 100,
+        title: 'ASMR',
+        closeFolders: true,
+        injectStyles: true,
+        touchStyles: 1,
+      }
+    );
     dragControls = new DragControls(draggableObjects, camera, renderer.domElement);
     dragControls.transformGroup = true;
+    soundCloudActive = false;
 
     const player = new THREE.Object3D();
     player.position.set(0, 0, 0);
@@ -312,14 +328,16 @@
   });
 </script>
 
-<div style="width: 100%; height: 80vh;" bind:this={container}>
-  {#if loading}
-    <div class="flex justify-center items-center h-full">
-      <div class="animate-spin rounded-full h-32 w-32 border-t-2 border-b-2 border-gray-900"></div>
-    </div>
-  {/if}
+<div class="flex">
+  <div style="width: 100vw; height: 80vh;" bind:this={container}>
+    {#if loading}
+      <div class="flex justify-center items-center h-full">
+        <div class="animate-spin rounded-full h-32 w-32 border-t-2 border-b-2 border-gray-900"></div>
+      </div>
+    {/if}
+  </div>
 </div>
-<div class="flex justify-center items-center space-x-2 pt-4">
+<div class="flex justify-center items-center space-x-2 pt-4 overflow-y-auto">
   <Button
     disabled={modelLoading}
     class="{audioPlaying['fireplace'] ? 'bg-green-500' : 'bg-gray-300'} {audioPlaying['fireplace'] ? 'hover:bg-yellow-600' : 'hover:bg-green-600'}"
@@ -392,4 +410,12 @@
       gui,
     )
   }>📱</Button>
+  <Button
+    disabled={modelLoading}
+    class="{audioPlaying['piano'] ? 'bg-green-500' : 'bg-gray-300'} {audioPlaying['piano'] ? 'hover:bg-yellow-600' : 'hover:bg-green-600'}"
+    on:click={() => {activateSoundCloud()}}
+  >🎹</Button>
+  {#if soundCloudActive}
+    <BottomDrawer />
+  {/if}
 </div>

--- a/web/src/routes/asmr/soundButton.svelte
+++ b/web/src/routes/asmr/soundButton.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import { Button } from "$lib/components/ui/button/index.js";
+  import { onMount, onDestroy } from 'svelte';
+
+  export let isOpen = false;
+
+  function toggleDrawer() {
+    isOpen = !isOpen;
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      isOpen = false;
+    }
+  }
+
+  function handleClickOutside(event: MouseEvent) {
+    const backdrop = event.target as HTMLElement;
+    if (backdrop.classList.contains('backdrop')) {
+      isOpen = false;
+    }
+  }
+
+  // 키보드 이벤트 리스너 등록/제거
+  onMount(() => {
+    window.addEventListener('keydown', handleKeydown);
+  });
+
+  onDestroy(() => {
+    window.removeEventListener('keydown', handleKeydown);
+  });
+</script>
+
+<Button  variant="outline" on:click={toggleDrawer}>🎵</Button>
+
+{#if isOpen}
+  <div 
+    class="backdrop fixed inset-0 transition-opacity duration-300 ease-out z-0"
+    on:click={handleClickOutside}
+    class:opacity-0={!isOpen}
+    class:opacity-100={isOpen}
+  />
+{/if}
+
+<div class="fixed bottom-0 left-0 w-full">
+  <div
+    class="fixed bottom-0 left-0 w-full h-1/2 bg-white shadow-lg p-4 z-1 transition-transform duration-300 ease-out"
+    class:translate-y-0={isOpen}
+    class:translate-y-full={!isOpen}
+  >
+    <div class="w-full h-[calc(100%-2rem)]">
+      <iframe
+        width="100%"
+        height="100%"
+        scrolling="yes"
+        frameborder="no"
+        allow="autoplay"
+        src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/300494469&color=%23252503&auto_play=true&hide_related=true&show_comments=false&show_user=false&show_reposts=false&show_teaser=false&visual=false">
+      </iframe>
+      <div style="font-size: 10px; color: #cccccc;line-break: anywhere;word-break: normal;overflow: hidden;white-space: nowrap;text-overflow: ellipsis; font-family: Interstate,Lucida Grande,Lucida Sans Unicode,Lucida Sans,Garuda,Verdana,Tahoma,sans-serif;font-weight: 100;">
+        <a href="https://soundcloud.com/chillhopdotcom" title="" target="_blank" style="color: #cccccc; text-decoration: none;"></a>
+        <a href="https://soundcloud.com/chillhopdotcom/sets/lofihiphop" title="" target="_blank" style="color: #cccccc; text-decoration: none;"></a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style lang="postcss">
+  .backdrop {
+    backdrop-filter: blur(2px);
+  }
+</style>


### PR DESCRIPTION
closes #1 

---

## 기본 음원 크기문제

- 모든 음원의 볼륨 기본값을 60% 올림
- 볼륨범위는 상단의 드롭다운메뉴에서 0 ~ 400% 조절 가능


## 음원추가

![image](https://github.com/user-attachments/assets/cf0d8d9a-4399-4bef-902a-ee4c40130361)

건반 버튼을 누르면 오른쪽에 음표 버튼이 생성됨.

> 굳이 이런 행위가 필요하진 않지만 중간에 다른 이벤트 확장을 위해 depth 를 하나 추가함

음표 버튼을 누르면 하단에 플레이리스트 드로워가 생성됨

---

[SUNO](https://suno.com/), [freesound](https://freesound.org/), [pixabay: sound](https://pixabay.com/sound-effects/) 같은 서비스에서 음원을 생성, 수집해도 괜찮긴할텐데.. 검증되지 않은 사운드를 듣고싶어하는 사람은 없을 것 같다는 생각이 들어서 바로 치워버리고

[Soundcloud: lo-fi hiphop](https://soundcloud.com/search?q=lofi%20hiphop) 에서 괜찮아보이는 플레이리스트 사용

embed 플레이어가 제공되는데 이걸 어떻게 사용할까 고민하다가 drawer 방식으로 화면 구성에 추가함.